### PR TITLE
README: fix module name

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -27,7 +27,7 @@ to read one again for any Perl module.
 
 =head2 Documentation
 
-To read about L<Tie::Cycle>, look at the embedded documentation
+To read about L<Text::MultiMarkdown>, look at the embedded documentation
 in the module itself. Inside the distribution, you can format it
 with L<perldoc|https://perldoc.perl.org/perldoc.html>:
 


### PR DESCRIPTION
Tie::Cycle here was probably a result of copy&paste.