### PR TITLE
use List::Util instead of List::MoreUtils for `uniq`

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -64,7 +64,7 @@ my %WriteMakefile = (
 
 	'TEST_REQUIRES' => {
 		'FindBin'         => '0',
-		'List::MoreUtils' => '0',
+		'List::Util'      => '1.45',
 		'Test::Exception' => '0',
 		'Test::More'      => '0.42',
 		},

--- a/t/lib/TestUtils.pm
+++ b/t/lib/TestUtils.pm
@@ -3,7 +3,7 @@ use strict;
 
 use Encode;
 use File::Spec::Functions qw(catfile);
-use List::MoreUtils qw(uniq);
+use List::Util qw(uniq);
 use Test::More;
 
 our $TIDY = eval { require HTML::Tidy };


### PR DESCRIPTION
Suggestion: use `List::Util` for `uniq` instead of `List::MoreUtils`.  The former comes bundled with Perl and as of 1.45 also has a uniq function.